### PR TITLE
Don't account for KeyError

### DIFF
--- a/CG-Acc/__main__.py
+++ b/CG-Acc/__main__.py
@@ -951,7 +951,7 @@ def get_br_el_sub_name_list(year, dep, sem_num, br_dict, el_dict, dep_dict, cont
                         el_dict[sub_name] = {}
                         for item in grade_list:
                             el_dict[sub_name][item] = 0
-                        el_dict[sub_name][sub_grade] += 1
+                        #el_dict[sub_name][sub_grade] += 1
                 elif sub_type.find('Breadth') != -1 or sub_type.find('HSS') != -1:
                     try:
                         br_dict[sub_name]
@@ -960,7 +960,7 @@ def get_br_el_sub_name_list(year, dep, sem_num, br_dict, el_dict, dep_dict, cont
                         br_dict[sub_name] = {}
                         for item in grade_list:
                             br_dict[sub_name][item] = 0
-                        br_dict[sub_name][sub_grade] += 1
+                        #br_dict[sub_name][sub_grade] += 1
                 if sub_type.find('Depth') != -1:
                     try:
                         dep_dict[sub_name]
@@ -969,7 +969,7 @@ def get_br_el_sub_name_list(year, dep, sem_num, br_dict, el_dict, dep_dict, cont
                         dep_dict[sub_name] = {}
                         for item in grade_list:
                             dep_dict[sub_name] = [0] * 8
-                        dep_dict[sub_name][sub_grade_dict[sub_grade]] += 1
+                        #dep_dict[sub_name][sub_grade_dict[sub_grade]] += 1
         elif line.find("<tr><td bgcolor=\"#FFF3FF\" colspan=\"2\"><h3 align=\"center\">Semester no:") != -1:
             matchObj = re.match(r'<tr><td bgcolor="#FFF3FF" colspan="2"><h3 align="center">Semester no: ([1-9]).*', line, re.M|re.I)
             if matchObj:


### PR DESCRIPTION
#8

Elements in dict were updated for missing keys irrespective of the KeyError
There's one issue though : The total doesn't add up for 3.1=>5 => CS
Total is fine for 3.1 => 3 => CS
Attached screenshots after change : 

![3 1_13cs_sem5](https://cloud.githubusercontent.com/assets/11318551/19828984/4878e9fe-9df3-11e6-9fdd-f4756411814c.png)
![3 2_13cs_sem5](https://cloud.githubusercontent.com/assets/11318551/19828985/48c599c0-9df3-11e6-864c-33546ec16c0b.png)
![3 3_13cs_sem5](https://cloud.githubusercontent.com/assets/11318551/19828986/494dd95c-9df3-11e6-82c8-5ddf5d92a648.png)
